### PR TITLE
Cache and performance enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ Scarf is configured using environment variables. Here are the most important one
 | `DB_PATH`           | Path to the SQLite database file for the cache.                             | `./data/indexer-cache.db`    |
 | `WEB_UI`            | Enable or disable the web UI.                                               | `true`                       |
 | `DEBUG`             | Enable debug logging.                                                       | `false`                      |
-| `UI_PASSWORD`       | Password to protect the web UI. **Set this!** | `password`                   |
+| `UI_PASSWORD`       | Password to protect the web UI. **Set this!**                               | `password`                   |
 | `FLEXGET_API_KEY`   | The API key for accessing the Torznab feed.                                 | (auto-generated 16 chars)    |
 | `JWT_SECRET`        | A secret key for signing session tokens.                                    | (auto-generated 32 chars)    |
 | `FLARESOLVERR_URL`  | The url pointing to the FlareSolverr service                                |                              |
 | `DEFAULT_API_LIMIT` | Default number of results for API clients that don't support pagination.    | `100`                        |
+| `ENABLE_CRONJOBS`   | Enables or disables the job that caches the latest tracker releases         | `true`                       |
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Scarf is configured using environment variables. Here are the most important one
 | `APP_PORT`          | The port the application will listen on.                                    | `8080`                       |
 | `DEFINITIONS_PATH`  | Path to the indexer definition files.                                       | `./definitions`              |
 | `CACHE_TTL`         | How long to cache search results.                                           | `15m`                        |
+| `LATEST_CACHE_TTL`  | How long to cache the latest releases.                                      | `24h`                        |
 | `DB_PATH`           | Path to the SQLite database file for the cache.                             | `./data/indexer-cache.db`    |
 | `WEB_UI`            | Enable or disable the web UI.                                               | `true`                       |
 | `DEBUG`             | Enable debug logging.                                                       | `false`                      |

--- a/api/cache_helpers.go
+++ b/api/cache_helpers.go
@@ -22,6 +22,13 @@ func GenerateCacheKey(indexerKey, query, category string) string {
 	return fmt.Sprintf("%x", hash)
 }
 
+// GenerateLatestCacheKey generates a standardized cache key for scheduled job results.
+func GenerateLatestCacheKey(indexerKey string) string {
+	keyStr := fmt.Sprintf("latest:%s", indexerKey)
+	hash := sha1.Sum([]byte(keyStr))
+	return fmt.Sprintf("%x", hash)
+}
+
 // CachedSearchResult represents the standardized cached search data
 type CachedSearchResult struct {
 	Results    []indexer.SearchResult `json:"results"`

--- a/config/config.go
+++ b/config/config.go
@@ -25,9 +25,10 @@ type ConfigOptions struct {
 	JWTSecret          string
 	FlareSolverrURL    string
 	InsecureSkipVerify bool
-	MaxCacheSize       int64         // New: Maximum cache size in MB
-	RequestTimeout     time.Duration // New: HTTP request timeout
-	DefaultAPILimit    int           // New: Default number of results for API
+	MaxCacheSize       int64
+	RequestTimeout     time.Duration
+	DefaultAPILimit    int
+	CronjobsEnabled    bool
 }
 
 // GetConfig loads and validates all configuration from environment variables
@@ -47,6 +48,7 @@ func GetConfig() (*ConfigOptions, error) {
 		MaxCacheSize:       GetEnvAsInt64("MAX_CACHE_SIZE_MB", 500) * 1024 * 1024, // Convert MB to bytes
 		RequestTimeout:     GetEnvAsDuration("REQUEST_TIMEOUT", 20*time.Second),
 		DefaultAPILimit:    GetEnvAsInt("DEFAULT_API_LIMIT", 100),
+		CronjobsEnabled:    GetEnvAsBool("ENABLE_CRONJOBS", true),
 	}
 
 	// Validate configuration

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type ConfigOptions struct {
 	AppPort            string
 	DefinitionsPath    string
 	CacheTTL           time.Duration
+	LatestCacheTTL     time.Duration
 	DBPath             string
 	WebUIEnabled       bool
 	DebugMode          bool
@@ -37,6 +38,7 @@ func GetConfig() (*ConfigOptions, error) {
 		AppPort:            GetEnv("APP_PORT", "8080"),
 		DefinitionsPath:    GetEnv("DEFINITIONS_PATH", "./definitions"),
 		CacheTTL:           GetEnvAsDuration("CACHE_TTL", 15*time.Minute),
+		LatestCacheTTL:     GetEnvAsDuration("LATEST_CACHE_TTL", 24*time.Hour),
 		DBPath:             GetEnv("DB_PATH", "./data/indexer-cache.db"),
 		WebUIEnabled:       GetEnvAsBool("WEB_UI", true),
 		DebugMode:          GetEnvAsBool("DEBUG", false),
@@ -74,6 +76,9 @@ func (c *ConfigOptions) Validate() error {
 	// Validate durations
 	if c.CacheTTL < time.Minute {
 		return fmt.Errorf("CACHE_TTL must be at least 1 minute, got: %s", c.CacheTTL)
+	}
+	if c.LatestCacheTTL < time.Hour {
+		return fmt.Errorf("LATEST_CACHE_TTL must be at least 1 hour, got: %s", c.LatestCacheTTL)
 	}
 	if c.RequestTimeout < time.Second {
 		return fmt.Errorf("REQUEST_TIMEOUT must be at least 1 second, got: %s", c.RequestTimeout)

--- a/main.go
+++ b/main.go
@@ -242,6 +242,7 @@ func main() {
 	// Torznab API endpoints
 	r.Get("/torznab/{indexer}/api", apiHandler.TorznabAPI)
 	r.Get("/torznab/{indexer}", apiHandler.TorznabSearch)
+	r.Get("/torznab/{indexer}/latest", apiHandler.TorznabLatest)
 
 	if !cfg.WebUIEnabled {
 		slog.Info("Web UI is disabled")

--- a/main.go
+++ b/main.go
@@ -148,6 +148,21 @@ func main() {
 						return
 					}
 					slog.Info("Scheduler: Successfully fetched releases", "indexer", indexerDef.Name, "count", len(results))
+
+					if len(results) > 0 {
+						// Use a long TTL, e.g., 24 hours, as this is for the latest feed.
+						ttl := 24 * time.Hour
+						latestCacheKey := api.GenerateLatestCacheKey(indexerKey)
+						cachedResult := api.CachedSearchResult{
+							Results:    results,
+							CachedAt:   time.Now(),
+							IndexerKey: indexerKey,
+						}
+						if jsonData, err := json.Marshal(cachedResult); err == nil {
+							appCache.Set(latestCacheKey, jsonData, ttl)
+							slog.Debug("Scheduler: Cached latest results", "indexer", indexerDef.Name, "key", latestCacheKey)
+						}
+					}
 				})
 				if err != nil {
 					slog.Warn("Could not schedule job", "indexer", def.Name, "error", err)

--- a/main.go
+++ b/main.go
@@ -150,8 +150,6 @@ func main() {
 					slog.Info("Scheduler: Successfully fetched releases", "indexer", indexerDef.Name, "count", len(results))
 
 					if len(results) > 0 {
-						// Use a long TTL, e.g., 24 hours, as this is for the latest feed.
-						ttl := 24 * time.Hour
 						latestCacheKey := api.GenerateLatestCacheKey(indexerKey)
 						cachedResult := api.CachedSearchResult{
 							Results:    results,
@@ -159,7 +157,8 @@ func main() {
 							IndexerKey: indexerKey,
 						}
 						if jsonData, err := json.Marshal(cachedResult); err == nil {
-							appCache.Set(latestCacheKey, jsonData, ttl)
+							// Use the new dedicated TTL for 'latest' results
+							appCache.Set(latestCacheKey, jsonData, cfg.LatestCacheTTL)
 							slog.Debug("Scheduler: Cached latest results", "indexer", indexerDef.Name, "key", latestCacheKey)
 						}
 					}

--- a/main.go
+++ b/main.go
@@ -115,58 +115,63 @@ func main() {
 	}
 
 	// --- Scheduler Setup ---
-	c := cron.New()
+	if cfg.CronjobsEnabled {
+		slog.Info("Scheduler is enabled")
+		c := cron.New()
 
-	// Function to update scheduled jobs when indexers are reloaded
-	updateScheduledJobs := func() {
-		slog.Info("Updating scheduled jobs after indexer reload...")
+		// Function to update scheduled jobs when indexers are reloaded
+		updateScheduledJobs := func() {
+			slog.Info("Updating scheduled jobs after indexer reload...")
 
-		// Stop existing cron jobs and create a new scheduler
-		if c != nil {
-			c.Stop()
-		}
-		c = cron.New()
-
-		// Re-add jobs for all indexers with schedules
-		jobCount := 0
-		for key, def := range idxManager.GetAllIndexers() {
-			if def.Schedule == "" || !def.Enabled {
-				continue
+			// Stop existing cron jobs and create a new scheduler
+			if c != nil {
+				c.Stop()
 			}
-			indexerKey, indexerDef := key, def
-			_, err := c.AddFunc(def.Schedule, func() {
-				slog.Info("Scheduler: Running job", "indexer", indexerDef.Name)
-				// Create a new context with the configured timeout
-				ctx, cancel := context.WithTimeout(context.Background(), cfg.RequestTimeout*2) // Give scheduled jobs double timeout
-				defer cancel()
+			c = cron.New()
 
-				results, err := idxManager.Search(ctx, indexerKey, indexer.SearchParams{})
-				if err != nil {
-					slog.Error("Scheduler: Failed to fetch latest", "indexer", indexerDef.Name, "error", err)
-					return
+			// Re-add jobs for all indexers with schedules
+			jobCount := 0
+			for key, def := range idxManager.GetAllIndexers() {
+				if def.Schedule == "" || !def.Enabled {
+					continue
 				}
-				slog.Info("Scheduler: Successfully fetched releases", "indexer", indexerDef.Name, "count", len(results))
-			})
-			if err != nil {
-				slog.Warn("Could not schedule job", "indexer", def.Name, "error", err)
+				indexerKey, indexerDef := key, def
+				_, err := c.AddFunc(def.Schedule, func() {
+					slog.Info("Scheduler: Running job", "indexer", indexerDef.Name)
+					// Create a new context with the configured timeout
+					ctx, cancel := context.WithTimeout(context.Background(), cfg.RequestTimeout*2) // Give scheduled jobs double timeout
+					defer cancel()
+
+					results, err := idxManager.Search(ctx, indexerKey, indexer.SearchParams{})
+					if err != nil {
+						slog.Error("Scheduler: Failed to fetch latest", "indexer", indexerDef.Name, "error", err)
+						return
+					}
+					slog.Info("Scheduler: Successfully fetched releases", "indexer", indexerDef.Name, "count", len(results))
+				})
+				if err != nil {
+					slog.Warn("Could not schedule job", "indexer", def.Name, "error", err)
+				} else {
+					jobCount++
+				}
+			}
+
+			if jobCount > 0 {
+				c.Start()
+				slog.Info("Scheduler updated", "jobs", jobCount)
 			} else {
-				jobCount++
+				slog.Info("No scheduled jobs configured")
 			}
 		}
 
-		if jobCount > 0 {
-			c.Start()
-			slog.Info("Scheduler updated", "jobs", jobCount)
-		} else {
-			slog.Info("No scheduled jobs configured")
-		}
+		// Set up initial scheduled jobs
+		updateScheduledJobs()
+
+		// Set the reload callback for the indexer manager
+		idxManager.SetReloadCallback(updateScheduledJobs)
+	} else {
+		slog.Info("Scheduler is disabled by environment variable")
 	}
-
-	// Set up initial scheduled jobs
-	updateScheduledJobs()
-
-	// Set the reload callback for the indexer manager
-	idxManager.SetReloadCallback(updateScheduledJobs)
 
 	// --- API Server Setup ---
 	r := chi.NewRouter()


### PR DESCRIPTION
This pull request introduces a host of significant enhancements and stability improvements focused on making the application more resilient, efficient, and user-friendly.

The key additions include a new "latest" releases endpoint and an intelligent system for auto-disabling failing indexers.

## Features

- **"Latest" Releases Endpoint**: A new `/torznab/{indexer}/latest` endpoint has been created to serve a pre-cached feed of the most recent releases. This allows clients like Flexget to get an instant response without triggering a live search.

- **Auto-Disabling of Failing Indexers**: The application can now automatically disable trackers that fail consistently. If an indexer fails more than `MAX_FAILURES` times within a 24-hour window, its .yml file will be modified to set enabled: "false". This feature can be configured via environment variables.

- **Configurable Cronjobs**: All scheduled jobs (cronjobs) can now be globally disabled by setting the `ENABLE_CRONJOBS=false` environment variable, which is ideal for low-resource devices or specific use cases.

## Enhancements

- **Separate Cache TTL for "Latest" Feed**: A new `LATEST_CACHE_TTL` environment variable has been introduced to allow a longer cache duration for the /latest endpoint, independent of the standard search TTL.

- **Intelligent Startup Jobs**: The initial run of scheduled jobs on application startup is now optimized:

  - **Conditional Execution**: A job only runs if its existing cache is older than its scheduled interval, preventing unnecessary server requests on frequent restarts.

  - **Concurrency Limiting**: A worker pool is now used to run startup jobs, preventing "database is locked" errors by limiting simultaneous cache writes.

- **Conditional "Indexer" Column in UI**: The search results table now includes an "Indexer" column that is dynamically shown only when performing a search across "All indexers," keeping the UI clean and relevant.

- **Improved Logging**: Logs for the /latest endpoint now clearly state whether a request was a cache HIT or MISS and include the timestamp of the cached data, greatly improving debuggability.
